### PR TITLE
[arrow] Bump Arrow Java to 19.0.0 and upgrade CI to Java 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Java 8 Build
+name: Java 11 Build
 
 on: [push, pull_request]
 
@@ -31,7 +31,7 @@ jobs:
       - name: Set JDK
         uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: 'temurin'
 
       - name: Set Maven 3.8.6

--- a/fluss-shaded-arrow-parent/fluss-shaded-arrow-19/pom.xml
+++ b/fluss-shaded-arrow-parent/fluss-shaded-arrow-19/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.fluss</groupId>
+        <artifactId>fluss-shaded-arrow-parent</artifactId>
+        <version>2.0-incubating</version>
+    </parent>
+
+    <artifactId>fluss-shaded-arrow${fluss.ci.license.suffix}</artifactId>
+    <name>fluss-shaded-arrow-19</name>
+    <version>${arrow.version}-2.0-incubating</version>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <!-- Arrow 19 requires Java 11+ -->
+        <arrow.version>19.0.0</arrow.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <version>${arrow.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-netty</artifactId>
+            <version>${arrow.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-buffer</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>license-check</id>
+            <properties>
+                <fluss.ci.license.suffix>-19</fluss.ci.license.suffix>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/fluss-shaded-arrow-parent/fluss-shaded-arrow-19/pom.xml
+++ b/fluss-shaded-arrow-parent/fluss-shaded-arrow-19/pom.xml
@@ -82,6 +82,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-variant</artifactId>
+            <version>${arrow.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/fluss-shaded-arrow-parent/fluss-shaded-arrow-19/src/main/resources/META-INF/NOTICE
+++ b/fluss-shaded-arrow-parent/fluss-shaded-arrow-19/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,14 @@
+fluss-shaded-arrow-19
+Copyright 2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.apache.arrow:arrow-vector:19.0.0
+- org.apache.arrow:arrow-format:19.0.0
+- org.apache.arrow:arrow-memory-core:19.0.0
+- org.apache.arrow:arrow-memory-netty:19.0.0
+- org.apache.arrow:arrow-memory-netty-buffer-patch:19.0.0
+- com.google.flatbuffers:flatbuffers-java:25.2.10

--- a/fluss-shaded-arrow-parent/fluss-shaded-arrow-19/src/main/resources/META-INF/NOTICE
+++ b/fluss-shaded-arrow-parent/fluss-shaded-arrow-19/src/main/resources/META-INF/NOTICE
@@ -11,4 +11,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.arrow:arrow-memory-core:19.0.0
 - org.apache.arrow:arrow-memory-netty:19.0.0
 - org.apache.arrow:arrow-memory-netty-buffer-patch:19.0.0
+- org.apache.arrow:arrow-variant:19.0.0
 - com.google.flatbuffers:flatbuffers-java:25.2.10
+- org.apache.parquet:parquet-variant:1.17.0
+- org.apache.parquet:parquet-common:1.17.0
+- org.apache.parquet:parquet-column:1.17.0
+- org.apache.parquet:parquet-format-structures:1.17.0
+- org.apache.parquet:parquet-encoding:1.17.0

--- a/fluss-shaded-arrow-parent/pom.xml
+++ b/fluss-shaded-arrow-parent/pom.xml
@@ -60,6 +60,8 @@
                                     <include>io.netty:*</include>
                                     <!-- Only for Arrow 15.0.0 -->
                                     <include>org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap</include>
+                                    <!-- arrow-variant depends on parquet-variant -->
+                                    <include>org.apache.parquet:*</include>
                                 </includes>
                                 <excludes>
                                     <!-- We re-use fluss-shaded-jackson -->
@@ -87,6 +89,15 @@
                                     <!-- This needs to match the relocation pattern of fluss-shaded-jackson -->
                                     <pattern>com.fasterxml.jackson</pattern>
                                     <shadedPattern>${shading.prefix}.jackson2.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.parquet</pattern>
+                                    <shadedPattern>${shading.prefix}.arrow.org.apache.parquet</shadedPattern>
+                                </relocation>
+                                <!-- parquet-format-structures bundles its own shaded thrift -->
+                                <relocation>
+                                    <pattern>shaded.parquet</pattern>
+                                    <shadedPattern>${shading.prefix}.arrow.shaded.parquet</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/fluss-shaded-arrow-parent/pom.xml
+++ b/fluss-shaded-arrow-parent/pom.xml
@@ -34,6 +34,7 @@
     <modules>
         <module>fluss-shaded-arrow-15</module>
         <module>fluss-shaded-arrow-16</module>
+        <module>fluss-shaded-arrow-19</module>
     </modules>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
                                 <configuration>
                                     <rules>
                                         <requireJavaVersion>
-                                            <version>1.8.0</version>
+                                            <version>11</version>
                                         </requireJavaVersion>
                                         <requireMavenVersion>
                                             <!-- Maven version for releasing should match


### PR DESCRIPTION
  ## Summary
  - Add `fluss-shaded-arrow-19` module for Apache Arrow Java 19.0.0
  - Upgrade CI from Java 8 to Java 11 (required by Arrow 19)
  - Update release enforcer to require Java 11

  ## Details
  Arrow 19.0.0 targets Java 11 bytecode, which requires maven-shade-plugin 3.6.0+
  (for ASM support of Java 11 class format). The existing `java11` profile already
  configures this. All existing modules (arrow-15, arrow-16, netty, jackson, guava,
  zookeeper) continue to build successfully on Java 11.